### PR TITLE
Update meta tags for OG image in index and contact pages

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -18,7 +18,7 @@
     <meta name="twitter:creator" content="@projecteuropa">
     <meta name="twitter:title" content="Contact // Project Europa">
     <meta name="twitter:description" content="Team Project Europaへのお問い合わせページです。Webサイト・Webアプリケーション制作のご依頼やご質問はこちらからどうぞ。">
-    <meta name="twitter:image" content="https://project-europa.com/images/ogp-contact.jpg">
+    <meta property="og:image" content="https://hp.project-europa.work/images/ogp.jpeg">
     
     <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@300;400;600&family=Rajdhani:wght@300;400;500&family=Electrolize&family=Share+Tech+Mono&display=swap" rel="stylesheet">
     <style>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <meta name="twitter:creator" content="@projecteuropa">
     <meta name="twitter:title" content="Project Europa // Cybernetic Interface">
     <meta name="twitter:description" content="Team Project Europaはフリーランス（個人事業主）としてWebサイト・Webアプリケーションの制作を行っています。">
-    <meta name="twitter:image" content="https://project-europa.com/images/ogp.jpg">
+    <meta property="og:image" content="https://hp.project-europa.work/images/ogp.jpeg">
     
     <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@300;400;600&family=Rajdhani:wght@300;400;500&family=Electrolize&family=Share+Tech+Mono&display=swap" rel="stylesheet">
     <style>


### PR DESCRIPTION
Replaced `twitter:image` with `og:image` meta property and updated the image URL to a new location. This ensures proper rendering of the Open Graph image for both the index and contact pages.