### PR TITLE
Add Advanced Networking Specialty skill to skills section

### DIFF
--- a/skill.html
+++ b/skill.html
@@ -236,10 +236,24 @@
             <p class="skill-desc">Comprehensive understanding of the AWS Cloud, its services, and basic architecture patterns.</p>
             <p class="skill-desc-jp">AWSクラウド、そのサービス、および基本的なアーキテクチャパターンの包括的な理解。</p>
           </div>
+          
+          <!-- Advanced Networking Specialty -->
+          <div class="skill-card">
+            <div class="skill-icon">
+              <div class="skill-icon-inner">
+                <svg viewBox="0 0 24 24">
+                  <path d="M15,20A1,1 0 0,0 16,19V4H8A1,1 0 0,0 7,5V16H5V5A3,3 0 0,1 8,2H19A3,3 0 0,1 22,5V19A3,3 0 0,1 19,22H15V20M1,15H3V17H1V15M1,11H3V13H1V11M1,7H3V9H1V7M1,3H3V5H1V3M5,3H7V5H5V3M5,19H7V21H5V19M5,11H7V13H5V11M5,7H7V9H5V7M9,3H11V5H9V3M9,19H11V21H9V19Z" />
+                </svg>
+              </div>
+            </div>
+            <h3 class="skill-title">Advanced Networking Specialty</h3>
+            <p class="skill-desc">Expert in designing, developing, and deploying complex networking solutions on AWS infrastructure.</p>
+            <p class="skill-desc-jp">AWS インフラストラクチャ上での複雑なネットワーキングソリューションの設計、開発、デプロイに関する専門知識。</p>
+          </div>
         </div>
 
         <div class="certification-note">
-          <p>※ Advanced Networking Specialty (ANS) を除く全ての AWS 認定資格を取得しています。</p>
+          <p>※ AWS の全ての認定資格を取得しています。</p>
           <p class="skill-desc">These certifications demonstrate our expertise across the entire AWS platform, enabling us to design, implement, and operate sophisticated cloud solutions for various business needs.</p>
           <p class="skill-desc-jp">これらの認定資格は、AWSプラットフォーム全体に渡る専門知識を証明し、様々なビジネスニーズに対応した高度なクラウドソリューションの設計、実装、運用を可能にします。</p>
         </div>


### PR DESCRIPTION
Introduced a new skill card highlighting expertise in Advanced Networking Specialty on AWS. Updated certification note to reflect the inclusion of this qualification, demonstrating mastery over all AWS certifications.